### PR TITLE
Remove duplicate ports for runner service in docker-compose.yml

### DIFF
--- a/examples/dockerdev/docker-compose.yml
+++ b/examples/dockerdev/docker-compose.yml
@@ -45,7 +45,6 @@ services:
     <<: *backend
     command: /bin/bash
     ports:
-      - '3000:3000'
       - '3002:3002'
 
   rails:


### PR DESCRIPTION
Remove duplicate port `3000` from `runner` service as this port is already assigned to `rails` service https://github.com/evilmartians/terraforming-rails/blob/master/examples/dockerdev/docker-compose.yml#L55

BTW, I think that there is no need to port-forward any ports except `rails` and `webpacker` services - all communication is going thru internal docker network. We shouldn't communicate with `redis` or `postgres` service from localhost - only thru `runner` service, that is the whole idea of development env via docker-compose.

Anyway, what is the purpose for `3002` port of `runner` service? :smiley:

