### PR TITLE
Use dictionary to organize environment varibales in Docker Compose configuration

### DIFF
--- a/examples/dockerdev/docker-compose.yml
+++ b/examples/dockerdev/docker-compose.yml
@@ -10,6 +10,9 @@ x-app: &app
       NODE_MAJOR: '11'
       YARN_VERSION: '1.13.0'
       BUNDLER_VERSION: '2.0.2'
+    environment: &env
+      NODE_ENV: development
+      RAILS_ENV: ${RAILS_ENV:-development}
   image: example-dev:1.0.0
   tmpfs:
     - /tmp
@@ -26,16 +29,15 @@ x-backend: &backend
     - packs:/app/public/packs
     - .dockerdev/.psqlrc:/root/.psqlrc:ro
   environment:
-    - NODE_ENV=development
-    - RAILS_ENV=${RAILS_ENV:-development}
-    - REDIS_URL=redis://redis:6379/
-    - DATABASE_URL=postgres://postgres:postgres@postgres:5432
-    - BOOTSNAP_CACHE_DIR=/bundle/bootsnap
-    - WEBPACKER_DEV_SERVER_HOST=webpacker
-    - WEB_CONCURRENCY=1
-    - HISTFILE=/app/log/.bash_history
-    - PSQL_HISTFILE=/app/log/.psql_history
-    - EDITOR=vi
+    <<: *env
+    REDIS_URL: redis://redis:6379/
+    DATABASE_URL: postgres://postgres:postgres@postgres:5432
+    BOOTSNAP_CACHE_DIR: /bundle/bootsnap
+    WEBPACKER_DEV_SERVER_HOST: webpacker
+    WEB_CONCURRENCY: 1
+    HISTFILE: /app/log/.bash_history
+    PSQL_HISTFILE: /app/log/.psql_history
+    EDITOR: vi
   depends_on:
     - postgres
     - redis
@@ -65,7 +67,7 @@ services:
       - postgres:/var/lib/postgresql/data
       - ./log:/root/log:cached
     environment:
-      - PSQL_HISTFILE=/root/log/.psql_history
+      PSQL_HISTFILE: /root/log/.psql_history
     ports:
       - 5432
 
@@ -87,9 +89,8 @@ services:
       - node_modules:/app/node_modules
       - packs:/app/public/packs
     environment:
-      - NODE_ENV=${NODE_ENV:-development}
-      - RAILS_ENV=${RAILS_ENV:-development}
-      - WEBPACKER_DEV_SERVER_HOST=0.0.0.0
+      <<: *env
+      WEBPACKER_DEV_SERVER_HOST: 0.0.0.0
 
 volumes:
   postgres:


### PR DESCRIPTION
Dictionaries could be merged and it allows to DRY the config.

Maybe it's not so essential in that particular config but it provides a good reference for further specific changes.