### PR TITLE
Remove require of rubocop/rspec/language in lint_env

### DIFF
--- a/tools/lint_env/lint_env.rb
+++ b/tools/lint_env/lint_env.rb
@@ -1,5 +1,3 @@
-require "rubocop/rspec/language"
-
 module RuboCop
   module Cop
     module Lint


### PR DESCRIPTION
Just removing the require, it's not been used and cause an error in projects without the 'rubocop-rspec' gem