### PR TITLE
really install the requested version of bundler

### DIFF
--- a/examples/dockerdev/.dockerdev/Dockerfile
+++ b/examples/dockerdev/.dockerdev/Dockerfile
@@ -56,7 +56,9 @@ ENV LANG=C.UTF-8 \
 
 # Upgrade RubyGems and install required Bundler version
 RUN gem update --system && \
-    gem install bundler:$BUNDLER_VERSION
+    rm /usr/local/lib/ruby/gems/*/specifications/default/bundler-*.gemspec && \
+    gem uninstall bundler && \
+    gem install bundler -v $BUNDLER_VERSION
 
 # Create a directory for the app code
 RUN mkdir -p /app

--- a/examples/dockerdev/.dockerdev/Dockerfile
+++ b/examples/dockerdev/.dockerdev/Dockerfile
@@ -55,6 +55,7 @@ ENV LANG=C.UTF-8 \
 # ENV PATH /app/bin:$PATH
 
 # Upgrade RubyGems and install required Bundler version
+# See https://github.com/evilmartians/terraforming-rails/pull/24 for discussion
 RUN gem update --system && \
     rm /usr/local/lib/ruby/gems/*/specifications/default/bundler-*.gemspec && \
     gem uninstall bundler && \


### PR DESCRIPTION
fixes #23 

Bundler won't uninstall because it is a 'default' gem and you won't end up running the version you added. Deleting the default gemspec first removes its protection. 'dip bundle -v' to check