### PR TITLE
dockerdev: Use only .dockerdev directory as build context

### DIFF
--- a/examples/dockerdev/.dockerdev/Dockerfile
+++ b/examples/dockerdev/.dockerdev/Dockerfile
@@ -31,7 +31,7 @@ RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \
   && echo 'deb http://dl.yarnpkg.com/debian/ stable main' > /etc/apt/sources.list.d/yarn.list
 
 # Install dependencies
-COPY .dockerdev/Aptfile /tmp/Aptfile
+COPY Aptfile /tmp/Aptfile
 RUN apt-get update -qq && DEBIAN_FRONTEND=noninteractive apt-get -yq dist-upgrade && \
   DEBIAN_FRONTEND=noninteractive apt-get install -yq --no-install-recommends \
     libpq-dev \

--- a/examples/dockerdev/docker-compose.yml
+++ b/examples/dockerdev/docker-compose.yml
@@ -2,8 +2,8 @@ version: '2.4'
 
 x-app: &app
   build:
-    context: .
-    dockerfile: ./.dockerdev/Dockerfile
+    context: .dockerdev
+    dockerfile: Dockerfile
     args:
       RUBY_VERSION: '2.6.3'
       PG_MAJOR: '11'


### PR DESCRIPTION
In large projects building of development docker image can be significantly slowed down by the large size of [build context](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#understand-build-context) (which is defaults to project directory that can be huge due to a large `.git` folder, log files, temporary files, etc).

One way to fix it is to exclude all large subdirectories from build context by specifying them in `.dockerignore` file.
Another–use `.dockerdev` directory as build context (it contains limited number of small files)–is in this pull request.

Fixes https://github.com/evilmartians/terraforming-rails/issues/26 (see it for more details and context)