### PR TITLE
Allow comments in Aptfile

### DIFF
--- a/examples/dockerdev/.dockerdev/Dockerfile
+++ b/examples/dockerdev/.dockerdev/Dockerfile
@@ -38,7 +38,7 @@ RUN apt-get update -qq && DEBIAN_FRONTEND=noninteractive apt-get -yq dist-upgrad
     postgresql-client-$PG_MAJOR \
     nodejs \
     yarn=$YARN_VERSION-1 \
-    $(cat /tmp/Aptfile | xargs) && \
+    $(grep -Ev '^\s*#' /tmp/Aptfile | xargs) && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* && \
     truncate -s 0 /var/log/*log


### PR DESCRIPTION
This change will enable commenting in the Aptfile, e.g.

```
imagemagick
# nano
  # vi
magic-wormhole
```