### PR TITLE
Adds step in Dockerfile to include freedesktop.org.xml

### DIFF
--- a/examples/dockerdev/.dockerdev/Dockerfile
+++ b/examples/dockerdev/.dockerdev/Dockerfile
@@ -14,10 +14,16 @@ RUN apt-get update -qq \
     curl \
     less \
     git \
+    shared-mime-info \
   && apt-get clean \
   && rm -rf /var/cache/apt/archives/* \
   && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \
   && truncate -s 0 /var/log/*log
+
+RUN cp /usr/share/mime/packages/freedesktop.org.xml ./ \
+  && apt-get remove -y --purge shared-mime-info \
+  && mkdir -p /usr/share/mime/packages \
+  && cp ./freedesktop.org.xml /usr/share/mime/packages/
 
 # Add PostgreSQL to sources list
 RUN curl -sSL https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - \


### PR DESCRIPTION
👋   I saw the terraforming-rails talk in person, and more recently the Ruby on Whales blogpost has been _crucial_ in helping me setup Docker at my company, thank you!

I wanted to give back, the Dockerfile used in the blogpost now requires `freedesktop.org.xml` to install the `mimemagic` gem as the `shared-mime-info` package is not installed on slim Docker images. It would be great to see a corresponding blog post update to help future Rails devs configure Docker for their Rails app without the mime headaches.

See also: https://github.com/docker-library/ruby/issues/344