### PR TITLE
Require a more recent dip version in the configuration file

### DIFF
--- a/examples/dockerdev/dip.yml
+++ b/examples/dockerdev/dip.yml
@@ -1,4 +1,4 @@
-version: '4.1'
+version: '6.1'
 
 environment:
   RAILS_ENV: development


### PR DESCRIPTION
Version 6.1 is the latest version that can be installed with
the Ruby provided by the current Mac OS. So let's go with that version.