### PR TITLE
Stop using non-portable shell syntax in the `.psqlrc`

### DIFF
--- a/examples/dockerdev/.dockerdev/.psqlrc
+++ b/examples/dockerdev/.dockerdev/.psqlrc
@@ -3,7 +3,7 @@
 
 -- Allow specifying the path to history file via `PSQL_HISTFILE` env variable
 -- (and fallback to the default $HOME/.psql_history otherwise)
-\set HISTFILE `[[ -z $PSQL_HISTFILE ]] && echo $HOME/.psql_history || echo $PSQL_HISTFILE`
+\set HISTFILE `[ -z $PSQL_HISTFILE ] && echo $HOME/.psql_history || echo $PSQL_HISTFILE`
 
 -- Show how long each query takes to execute
 \timing


### PR DESCRIPTION
The shell provided in the `postgres` container does not support
the `[[…]]` syntax, which causes `dip psql` to emit errors.

So we need to use the more portable syntax `[…]` here.