### PR TITLE
examples(dockerdev) Also (re-)build the containers on `dip provision`

### DIFF
--- a/examples/dockerdev/dip.yml
+++ b/examples/dockerdev/dip.yml
@@ -77,6 +77,7 @@ interaction:
 
 provision:
   - dip compose down --volumes
+  - dip compose build
   - dip compose up -d postgres redis
   - dip bundle install
   - dip yarn install


### PR DESCRIPTION
A change of the Docker configuration usually requires re-provisioning.
As rebuilding the containers is quite fast due to Docker caching,
we can include the container building step into `dip provision`
so that there is no second step to do after changing the
container configuration.