### PR TITLE
Disable clustered mode for Puma for the Docker example

### DIFF
--- a/examples/dockerdev/docker-compose.yml
+++ b/examples/dockerdev/docker-compose.yml
@@ -36,7 +36,7 @@ x-backend: &backend
     DATABASE_URL: postgres://postgres:postgres@postgres:5432
     BOOTSNAP_CACHE_DIR: /usr/local/bundle/_bootsnap
     WEBPACKER_DEV_SERVER_HOST: webpacker
-    WEB_CONCURRENCY: 1
+    WEB_CONCURRENCY: 0
     HISTFILE: /app/log/.bash_history
     PSQL_HISTFILE: /app/log/.psql_history
     EDITOR: vi


### PR DESCRIPTION
Puma is not intended to be used in clustered mode for local development
and emits a warning on start if it is configured to use one worker
in clustered mode (instead of 0 workers, which disables clustered mode).