### PR TITLE
feat(dockerdev): Add a volume for testing packs

### DIFF
--- a/examples/dockerdev/docker-compose.yml
+++ b/examples/dockerdev/docker-compose.yml
@@ -29,6 +29,7 @@ x-backend: &backend
     - bundle:/usr/local/bundle
     - node_modules:/app/node_modules
     - packs:/app/public/packs
+    - packs-test:/app/public/packs-test
     - .dockerdev/.psqlrc:/root/.psqlrc:ro
     - .dockerdev/.bashrc:/root/.bashrc:ro
   environment:
@@ -113,3 +114,4 @@ volumes:
   node_modules:
   rails_cache:
   packs:
+  packs-test:


### PR DESCRIPTION
This allows the packs that get created when specs are run to be cached
inbetween builds, thus improving performance for the pack-related test
in a run.