### PR TITLE
Add selinux label for app directory

### DIFF
--- a/examples/dockerdev/docker-compose.yml
+++ b/examples/dockerdev/docker-compose.yml
@@ -24,7 +24,7 @@ x-backend: &backend
   stdin_open: true
   tty: true
   volumes:
-    - .:/app:cached
+    - .:/app:cached,z
     - rails_cache:/app/tmp/cache
     - bundle:/usr/local/bundle
     - node_modules:/app/node_modules

--- a/examples/dockerdev/docker-compose.yml
+++ b/examples/dockerdev/docker-compose.yml
@@ -24,7 +24,9 @@ x-backend: &backend
   stdin_open: true
   tty: true
   volumes:
-    - .:/app:cached,z
+    - .:/app:cached
+    # or for selinux: https://docs.docker.com/storage/bind-mounts/#configure-the-selinux-label
+    # - .:/app:cached,z
     - rails_cache:/app/tmp/cache
     - bundle:/usr/local/bundle
     - node_modules:/app/node_modules


### PR DESCRIPTION
Without selinux `z` flag[^1] `app` directory has permission denied.

[^1]: https://docs.docker.com/storage/bind-mounts/#configure-the-selinux-label