### PR TITLE
fix(dockerdev): Install Yarn as npm instead of apt-get package

### DIFF
--- a/examples/dockerdev/.dockerdev/Dockerfile
+++ b/examples/dockerdev/.dockerdev/Dockerfile
@@ -39,10 +39,6 @@ RUN curl -sSL https://www.postgresql.org/media/keys/ACCC4CF8.asc | gpg --dearmor
 # Add NodeJS to sources list
 RUN curl -sL https://deb.nodesource.com/setup_$NODE_MAJOR.x | bash -
 
-# Add Yarn to the sources list
-RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | gpg --dearmor -o /usr/share/keyrings/yarn-archive-keyring.gpg \
-  && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/yarn-archive-keyring.gpg] https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list > /dev/null
-
 # Install dependencies
 COPY Aptfile /tmp/Aptfile
 RUN apt-get update -qq && DEBIAN_FRONTEND=noninteractive apt-get -yq dist-upgrade && \
@@ -50,7 +46,6 @@ RUN apt-get update -qq && DEBIAN_FRONTEND=noninteractive apt-get -yq dist-upgrad
     libpq-dev \
     postgresql-client-$PG_MAJOR \
     nodejs \
-    yarn=$YARN_VERSION-1 \
     $(grep -Ev '^\s*#' /tmp/Aptfile | xargs) && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* && \
@@ -78,3 +73,5 @@ RUN gem update --system && \
 RUN mkdir -p /app
 
 WORKDIR /app
+
+RUN npm install -g yarn@$YARN_VERSION

--- a/examples/dockerdev/docker-compose.yml
+++ b/examples/dockerdev/docker-compose.yml
@@ -8,8 +8,8 @@ x-app: &app
       RUBY_VERSION: '2.6.3'
       PG_MAJOR: '13'
       NODE_MAJOR: '14'
-      YARN_VERSION: '1.22.15'
       BUNDLER_VERSION: '2.2.28'
+      YARN_VERSION: '1.22.17'
   environment: &env
     NODE_ENV: ${NODE_ENV:-development}
     RAILS_ENV: ${RAILS_ENV:-development}


### PR DESCRIPTION
It's recommended to use Yarn as npm package and it's mandatory for Yarn versions > 1.
Additionally it seems there is an GPG key verification issue for the yarn source on M1 Macs.