### PR TITLE
Add keyword argument globbing for ruby 3

### DIFF
--- a/tools/templates_tracker/templates_tracker_rspec.rb
+++ b/tools/templates_tracker/templates_tracker_rspec.rb
@@ -47,7 +47,7 @@ module TemplatesTracker
   end
 
   module Ext
-    def initialize(*)
+    def initialize(*, **)
       super
       TemplatesTracker.track(@identifier)
     end


### PR DESCRIPTION
Otherwise you get an error like this:
```
     Failure/Error: super

     ArgumentError:
       wrong number of arguments (given 4, expected 3; required keyword: locals)
```