### PR TITLE
fix(dockerdev): Use the test packs mount in all affected containers

### DIFF
--- a/examples/dockerdev/docker-compose.yml
+++ b/examples/dockerdev/docker-compose.yml
@@ -105,6 +105,7 @@ services:
       - bundle:/usr/local/bundle
       - node_modules:/app/node_modules
       - packs:/app/public/packs
+      - packs-test:/app/public/packs-test
     environment:
       <<: *env
       WEBPACKER_DEV_SERVER_HOST: 0.0.0.0


### PR DESCRIPTION
The webpacker container should be able to access the mount for the
test packs as well.

This was missing in 3e2ad5ff14acd297d8355ba5ae37b1eddfe274bc.