### PR TITLE
fix(dockerdev): Remove obsolete Docker mount optimization

### DIFF
--- a/examples/dockerdev/docker-compose.yml
+++ b/examples/dockerdev/docker-compose.yml
@@ -32,8 +32,8 @@ x-backend: &backend
     - node_modules:/app/node_modules
     - packs:/app/public/packs
     - packs-test:/app/public/packs-test
-    - .dockerdev/.psqlrc:/root/.psqlrc:ro
-    - .dockerdev/.bashrc:/root/.bashrc:ro
+    - .dockerdev/.psqlrc:/root/.psqlrc
+    - .dockerdev/.bashrc:/root/.bashrc
   environment:
     <<: *env
     REDIS_URL: redis://redis:6379/
@@ -71,9 +71,9 @@ services:
   postgres:
     image: postgres:13.0
     volumes:
-      - .dockerdev/.psqlrc:/root/.psqlrc:ro
+      - .dockerdev/.psqlrc:/root/.psqlrc
       - postgres:/var/lib/postgresql/data
-      - ./log:/root/log:cached
+      - ./log:/root/log
     environment:
       PSQL_HISTFILE: /root/log/.psql_history
       POSTGRES_PASSWORD: postgres
@@ -101,7 +101,7 @@ services:
     ports:
       - '3035:3035'
     volumes:
-      - .:/app:cached
+      - .:/app
       - bundle:/usr/local/bundle
       - node_modules:/app/node_modules
       - packs:/app/public/packs


### PR DESCRIPTION
With current versions of Docker on Mac, those are not needed anymore.

https://github.com/docker/for-mac/issues/5402