### PR TITLE
Update Dangerfile

### DIFF
--- a/examples/danger/Dangerfile
+++ b/examples/danger/Dangerfile
@@ -13,7 +13,7 @@ def artefacts_link(name)
 end
 
 Dir[File.join(__dir__, ".danger/*.rb")].each do |danger_rule_file|
-  danger_rule = danger_rule_file.gsub(%r{(^./.danger/|.rb)}, "")
+  danger_rule = File.basename(danger_rule_file, File.extname(danger_rule_file))
   $stdout.print "- #{danger_rule} "
   eval File.read(danger_rule_file), binding, File.expand_path(danger_rule_file) # rubocop:disable Security/Eval
   $stdout.puts "✅"


### PR DESCRIPTION
I started using this, and had a file called `.danger/erblint.rb`. The gsub for `/.rb/` picked up the `erb` in `erblint`, and dropped it, so the name it printed was just "erb".

Instead of gsub, I updated it to use the File utils to more safely extract the name part from the filename.